### PR TITLE
docs: add missing author entries to Markdown files

### DIFF
--- a/.github/agents/architect.agent.md
+++ b/.github/agents/architect.agent.md
@@ -39,3 +39,6 @@ Return a **multi-file plan** in this exact structure:
 - Prefer incremental steps.
 - Include commands (build/test/lint) that should be run.
 - Call out any refactors or migrations explicitly.
+
+---
+**Author:** m-malli

--- a/.github/agents/developer.agent.md
+++ b/.github/agents/developer.agent.md
@@ -33,3 +33,6 @@ You are the **Developer agent**. You implement the Architect plan.
 - [ ] Update/extend tests if obvious gaps
 - [ ] Ensure compilation/build
 - [ ] Summarize changes & known limitations
+
+---
+**Author:** m-malli

--- a/.github/agents/qa.agent.md
+++ b/.github/agents/qa.agent.md
@@ -20,3 +20,6 @@ You are the **QA agent**. Your focus is correctness, coverage, and preventing re
 4. **Edge cases checked**
 5. **Risks / follow-ups**
 6. **Final status** (Pass / Pass with notes / Fail)
+
+---
+**Author:** m-malli

--- a/.github/agents/student.agent.md
+++ b/.github/agents/student.agent.md
@@ -9,3 +9,6 @@ handoffs:
     send: false
 ---
 You are a Student. Your role is to learn and answer questions posed by the Teacher.
+
+---
+**Author:** m-malli

--- a/.github/agents/teacher.agent.md
+++ b/.github/agents/teacher.agent.md
@@ -9,3 +9,6 @@ handoffs:
     send: false
 ---
 You are a School Teacher. Your role is to teach Math and pose questions to the Student to assess their understanding of the material.
+
+---
+**Author:** m-malli

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # coursepractice
 
 This repository contains practice code for learning and practicing GitHub Copilot Coding Agent.
+
+---
+**Author:** m-malli


### PR DESCRIPTION
## Summary

Adds a consistent `**Author:** m-malli` entry at the bottom of all Markdown files in the repository.

## Changes

| File | Change |
|------|--------|
| `README.md` | Added author entry |
| `.github/agents/architect.agent.md` | Added author entry |
| `.github/agents/developer.agent.md` | Added author entry |
| `.github/agents/qa.agent.md` | Added author entry |
| `.github/agents/student.agent.md` | Added author entry |
| `.github/agents/teacher.agent.md` | Added author entry |

## Format

```
---
**Author:** m-malli
```

Closes #4